### PR TITLE
Latex generate correct "other" pieces

### DIFF
--- a/board.py
+++ b/board.py
@@ -169,6 +169,7 @@ class Piece:
         # rest
         glyph= glyph.replace("a", "C")
         glyph= glyph.replace("f", "C")
+        glyph= glyph.replace("x", "C")
 
         # rotation of pieces
         glyph= glyph.replace("1", "R")

--- a/exporters/latex.py
+++ b/exporters/latex.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 # local
 import model
@@ -82,8 +82,7 @@ def entry(e, Lang):
     if 'algebraic' in e:
         b.fromAlgebraic(e['algebraic'])
         pieces = b.toLaTeX()
-        text = (text +
-            "  \\pieces[" + b.getPiecesCount() + "]{" + pieces + "}%\n")
+        text = (text + "  \\pieces{" + pieces + "}%\n")
 
     # stipulation
     text = text + "  \\stipulation{" + string2LaTeX(e['stipulation'])


### PR DESCRIPTION
- so far, the LaTeX exporter generated 'x' for "other" pieces, which caused LaTeX to produce errors
- I suggest generating 'C' (circle) instead
- I also suggest to stop generating piece counts in the \pieces LaTeX elements because they lead to conflicts with LaTeX for problems where olive-gui generates circles for pieces; LaTeX doesn't include circles in its piece counts, but olive-gui does include the corresponding pieces in its piece counts

NB: I don't understand the apparent difference on line #1 of latex.py