### PR TITLE
new condition Immobilio ... and 2 other improvements

### DIFF
--- a/conf/py-conditions.txt
+++ b/conf/py-conditions.txt
@@ -21,7 +21,7 @@ AntipodeanAntiCirce <select{|Cheylan|Calvet}>
 AntipodeanCirce
 AntipodeanImmunChess <select{|RexInclusiv}>
 AntiSuperCirce
-AprilChess
+AprilChess <str>
 ArgentinianChess
 BackToBack
 BGL
@@ -110,9 +110,10 @@ Heffalumps <select{|RexExclusiv}>
 Hole <str>
 Hypervolage
 Imitator <str>
+Immobilio <str>
 ImmunChess <select{|RexInclusiv}>
 Influencer
-Isardam <select{|TypeB}>
+Isardam <select{|TypeB}> <select{|RexInclusiv}>
 KoBulKings
 KoeKo
 Leffie


### PR DESCRIPTION
- Immobilio: supported since Popeye 4.99; will allow affected piece types to be specified in next Popeye release
- AprilChess: Popeye has always allowed affected piece types to be specified
- Isardam: RexInclusive possibility was misisng